### PR TITLE
Implement serial-based model selection

### DIFF
--- a/model_selector.py
+++ b/model_selector.py
@@ -1,0 +1,55 @@
+"""Utilities for selecting a model based on a serial or barcode prefix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from config_loader import load_config
+
+
+class ModelSelector:
+    """Select a model based on a serial number prefix.
+
+    Parameters
+    ----------
+    mapping : dict[str, str], optional
+        Mapping from serial prefixes to model names. If not provided,
+        ``config_path`` will be loaded and ``serialMapping`` will be used.
+    config_path : str or Path, optional
+        Path to a configuration file that contains ``serialMapping``.
+        Defaults to ``"config/config.json"``.
+    """
+
+    def __init__(self, mapping: Optional[Dict[str, str]] = None, config_path: str | Path = "config/config.json") -> None:
+        if mapping is not None:
+            self.mapping = mapping
+        else:
+            config = load_config(config_path)
+            self.mapping = config.get("serialMapping", {})
+
+    def select(self, serial: str, *, unknown: Optional[str] = None) -> Optional[str]:
+        """Return the model for ``serial`` or ``unknown`` if not found."""
+        if not serial:
+            return unknown
+        prefix = serial[:4]
+        return self.mapping.get(prefix, unknown)
+
+
+def select_model(serial: str, *, mapping: Optional[Dict[str, str]] = None, config_path: str | Path = "config/config.json", unknown: Optional[str] = None) -> Optional[str]:
+    """Convenience function to select a model given a serial.
+
+    Parameters
+    ----------
+    serial : str
+        Serial or barcode string. Only the first four characters are used.
+    mapping : dict[str, str], optional
+        Mapping from serial prefixes to model names. If not provided,
+        configuration will be loaded from ``config_path``.
+    config_path : str or Path, optional
+        Path to configuration file used when ``mapping`` is not supplied.
+    unknown : str, optional
+        Value returned when the prefix is not found. Defaults to ``None``.
+    """
+    selector = ModelSelector(mapping=mapping, config_path=config_path)
+    return selector.select(serial, unknown=unknown)

--- a/tests/test_model_selector.py
+++ b/tests/test_model_selector.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+from model_selector import ModelSelector, select_model
+
+
+def test_select_with_mapping():
+    mapping = {"AB12": "ModelA", "CD34": "ModelB"}
+    selector = ModelSelector(mapping=mapping)
+    assert selector.select("AB12XYZ") == "ModelA"
+    assert selector.select("CD34XYZ") == "ModelB"
+    assert selector.select("ZZ99") is None
+    assert selector.select("ZZ99", unknown="Unknown Model") == "Unknown Model"
+
+
+def test_select_with_config(tmp_path: Path):
+    config_data = {"serialMapping": {"EF56": "ModelC"}}
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(config_data))
+    selector = ModelSelector(config_path=cfg)
+    assert selector.select("EF56AAAA") == "ModelC"
+
+
+def test_select_model_function():
+    mapping = {"GH78": "ModelD"}
+    assert select_model("GH78XXXX", mapping=mapping) == "ModelD"
+    assert select_model("XXXX", mapping=mapping, unknown="Unknown") == "Unknown"


### PR DESCRIPTION
## Summary
- add `ModelSelector` utility with `select_model` helper
- unit tests for model selection from mapping and config

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580a78f41c8320a899168a8065dd1d