### PR TITLE
Add path management utility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is in sys.path
+ROOT = Path(__file__).resolve().parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/path_manager.py
+++ b/path_manager.py
@@ -1,0 +1,52 @@
+"""Utility for managing filesystem paths used by the application."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Mapping, Optional
+
+from config_loader import load_config
+
+
+class PathManager:
+    """Manage directories defined in configuration.
+
+    Parameters
+    ----------
+    path_map : Mapping[str, str | Path]
+        Mapping of path names to directory paths.
+    base_path : str or Path, optional
+        Base directory prepended to each path in ``path_map`` when provided.
+    """
+
+    def __init__(self, path_map: Mapping[str, str | Path], base_path: str | Path | None = None) -> None:
+        self.base_path = Path(base_path) if base_path is not None else None
+        self.paths: Dict[str, Path] = {}
+        for name, value in path_map.items():
+            p = Path(value)
+            if self.base_path is not None:
+                p = self.base_path / p
+            try:
+                p.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:  # pragma: no cover - very unlikely in tests
+                raise OSError(f"Failed to create directory {p}: {exc}") from exc
+            self.paths[name] = p
+
+    def __getitem__(self, item: str) -> Path:
+        return self.paths[item]
+
+    def get(self, item: str, default: Optional[Path] = None) -> Optional[Path]:
+        return self.paths.get(item, default)
+
+    def as_dict(self) -> Dict[str, Path]:
+        return dict(self.paths)
+
+
+def load_paths(config_path: str | Path = "config/config.json", *, base_path: str | Path | None = None) -> PathManager:
+    """Load path configuration and return a :class:`PathManager` instance."""
+    config = load_config(config_path)
+    path_map = config.get("paths", {})
+    if not isinstance(path_map, Mapping):
+        raise TypeError("'paths' section must be a mapping")
+    return PathManager(path_map, base_path=base_path)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the Python path for tests
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/tests/test_path_manager.py
+++ b/tests/test_path_manager.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from path_manager import PathManager, load_paths
+
+
+def test_load_paths_creates_directories(tmp_path: Path):
+    config = {"paths": {"images": "imgs", "logs": "logs"}}
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(config))
+
+    manager = load_paths(cfg)
+    assert manager["images"].is_dir()
+    assert manager["logs"].is_dir()
+    assert manager["images"].name == "imgs"
+
+
+def test_load_paths_with_base(tmp_path: Path):
+    config = {"paths": {"images": "images"}}
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps(config))
+
+    base = tmp_path / "base"
+    manager = load_paths(cfg, base_path=base)
+    expected = base / "images"
+    assert manager["images"] == expected
+    assert expected.is_dir()
+
+
+def test_path_manager_get(tmp_path: Path):
+    mapping = {"img": "i"}
+    manager = PathManager(mapping, base_path=tmp_path)
+    assert manager.get("img") == tmp_path / "i"
+    assert manager.get("missing") is None
+


### PR DESCRIPTION
## Summary
- add a `PathManager` class and `load_paths` convenience function
- ensure tests can import project modules via `conftest`
- add unit tests for `PathManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580c3d2b4c83208505daa2152c99d9