### PR TITLE
Add camera list length validation

### DIFF
--- a/camera_config.py
+++ b/camera_config.py
@@ -20,6 +20,9 @@ def load_cameras(config_path: str | Path = "config/config.json") -> List[Dict]:
 
 def validate_cameras(cameras: List[Dict]) -> None:
     """Validate that each camera has required fields based on its type."""
+    if len(cameras) < 1 or len(cameras) > 6:
+        raise ValueError("Camera list must contain between 1 and 6 items")
+
     for camera in cameras:
         camera_type = camera.get("type")
         if camera_type == "usb":

--- a/tests/test_camera_config.py
+++ b/tests/test_camera_config.py
@@ -24,6 +24,14 @@ def test_validate_cameras_errors():
         validate_cameras([{"type": "unknown"}])
 
 
+def test_validate_cameras_length_errors():
+    with pytest.raises(ValueError):
+        validate_cameras([])
+    cams = [{"type": "usb", "device": "/dev/null"}] * 7
+    with pytest.raises(ValueError):
+        validate_cameras(cams)
+
+
 def test_get_camera_status(tmp_path: Path):
     device = tmp_path / "cam"
     device.touch()
@@ -33,3 +41,4 @@ def test_get_camera_status(tmp_path: Path):
 
     keyence = {"type": "keyence", "ip": "1.2.3.4", "port": 8500}
     assert get_camera_status(keyence) == "online"
+


### PR DESCRIPTION
## Summary
- enforce camera list length limits in `validate_cameras`
- add tests for invalid camera counts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685810ec4784832095322cdc2a0f017c