### PR TITLE
Add dataclass-based camera loader

### DIFF
--- a/camera_config.py
+++ b/camera_config.py
@@ -4,8 +4,21 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List, Dict
+from dataclasses import dataclass
 
 from config_loader import ConfigLoader
+
+
+@dataclass
+class Camera:
+    """Representation of a camera defined in configuration."""
+
+    id: int
+    type: str
+    name: str
+    device: str | None = None
+    ip: str | None = None
+    port: int | None = None
 
 
 def load_cameras(config_path: str | Path = "config/config.json") -> List[Dict]:
@@ -16,6 +29,22 @@ def load_cameras(config_path: str | Path = "config/config.json") -> List[Dict]:
     if not isinstance(cameras, list):
         raise TypeError("'cameras' section must be a list")
     return cameras
+
+
+def load_camera_objects(config_path: str | Path = "config/config.json") -> List[Camera]:
+    """Load camera configuration and return a list of :class:`Camera` objects."""
+    camera_dicts = load_cameras(config_path)
+    return [
+        Camera(
+            id=cam.get("id"),
+            type=cam.get("type"),
+            name=cam.get("name"),
+            device=cam.get("device"),
+            ip=cam.get("ip"),
+            port=cam.get("port"),
+        )
+        for cam in camera_dicts
+    ]
 
 
 def validate_cameras(cameras: List[Dict]) -> None:

--- a/tests/test_camera_config.py
+++ b/tests/test_camera_config.py
@@ -3,7 +3,13 @@ from pathlib import Path
 
 import pytest
 
-from camera_config import load_cameras, validate_cameras, get_camera_status
+from camera_config import (
+    load_cameras,
+    load_camera_objects,
+    validate_cameras,
+    get_camera_status,
+    Camera,
+)
 
 
 def test_load_cameras(tmp_path: Path):
@@ -41,4 +47,33 @@ def test_get_camera_status(tmp_path: Path):
 
     keyence = {"type": "keyence", "ip": "1.2.3.4", "port": 8500}
     assert get_camera_status(keyence) == "online"
+
+
+def test_load_camera_objects(tmp_path: Path):
+    cfg = tmp_path / "cfg.json"
+    data = {
+        "cameras": [
+            {
+                "id": 1,
+                "type": "usb",
+                "name": "Cam",
+                "device": "/dev/null",
+            },
+            {
+                "id": 2,
+                "type": "keyence",
+                "name": "Key",
+                "ip": "1.2.3.4",
+                "port": 8500,
+            },
+        ]
+    }
+    cfg.write_text(json.dumps(data))
+
+    cameras = load_camera_objects(cfg)
+    assert len(cameras) == 2
+    assert isinstance(cameras[0], Camera)
+    assert cameras[0].device == "/dev/null"
+    assert cameras[1].ip == "1.2.3.4"
+    assert cameras[1].port == 8500
 


### PR DESCRIPTION
## Summary
- add `Camera` dataclass to `camera_config`
- add `load_camera_objects` for creating camera dataclass instances
- test dataclass loader alongside existing camera tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858118726e08320a07b474a5f80fbff