### PR TITLE
Add manual serial input utility

### DIFF
--- a/serial_input.py
+++ b/serial_input.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Callable, Any
+
+
+def validate_serial(serial: str) -> bool:
+    """Return ``True`` if ``serial`` is 4-20 alphanumeric characters."""
+    return serial.isalnum() and 4 <= len(serial) <= 20
+
+
+def get_serial(
+    prompt: str = "Enter serial: ",
+    *,
+    input_func: Callable[[str], str] = input,
+    output_func: Callable[[str], Any] = print,
+) -> str:
+    """Prompt for a serial number until a valid value is entered."""
+    while True:
+        value = input_func(prompt).strip()
+        if validate_serial(value):
+            return value
+        output_func("Invalid serial. Please enter 4-20 alphanumeric characters.")

--- a/tests/test_serial_input.py
+++ b/tests/test_serial_input.py
@@ -1,0 +1,27 @@
+import builtins
+
+from serial_input import validate_serial, get_serial
+
+
+def test_validate_serial():
+    assert validate_serial('AB12')
+    assert validate_serial('a1B2c3')
+    assert validate_serial('1' * 20)
+    assert not validate_serial('abc')
+    assert not validate_serial('a' * 21)
+    assert not validate_serial('123$')
+
+
+def test_get_serial(monkeypatch):
+    inputs = iter(['bad', '123$', 'SN1234'])
+    outputs = []
+
+    def fake_input(prompt: str) -> str:
+        return next(inputs)
+
+    def fake_print(msg: str) -> None:
+        outputs.append(msg)
+
+    result = get_serial(input_func=fake_input, output_func=fake_print)
+    assert result == 'SN1234'
+    assert len(outputs) == 2


### PR DESCRIPTION
## Summary
- provide `serial_input` module for manual serial entry with validation
- test `serial_input` helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858274c131083208b1809fad66c51f7