### PR TITLE
Add serial processing utility

### DIFF
--- a/serial_processor.py
+++ b/serial_processor.py
@@ -1,0 +1,49 @@
+"""Serial processing utilities decoupling input from downstream logic."""
+
+from __future__ import annotations
+
+from typing import Callable, Iterable, Any
+
+from serial_input import get_serial
+
+
+
+def process_serials(
+    process_func: Callable[[str], Any],
+    prompts: Iterable[str] = ("Enter serial 1: ", "Enter serial 2: "),
+    *,
+    retries: int = 0,
+    input_func: Callable[[str], str] = input,
+    output_func: Callable[[str], Any] = print,
+    log_func: Callable[[str], Any] = print,
+) -> None:
+    """Prompt for serial numbers and forward them to ``process_func``.
+
+    Parameters
+    ----------
+    process_func : Callable[[str], Any]
+        Function invoked with each validated serial.
+    prompts : iterable of str, optional
+        Prompts used when requesting serials. Defaults to two prompts.
+    retries : int, optional
+        Number of times to retry ``process_func`` when it raises an exception.
+    input_func : Callable[[str], str], optional
+        Function used to read user input. Defaults to ``input``.
+    output_func : Callable[[str], Any], optional
+        Function used to output validation messages. Defaults to ``print``.
+    log_func : Callable[[str], Any], optional
+        Function used to log processing errors. Defaults to ``print``.
+    """
+
+    for prompt in prompts:
+        serial = get_serial(prompt, input_func=input_func, output_func=output_func)
+        attempts = 0
+        while True:
+            try:
+                process_func(serial)
+                break
+            except Exception as exc:  # pragma: no cover - error path
+                log_func(f"Error processing {serial}: {exc}")
+                if attempts >= retries:
+                    break
+                attempts += 1

--- a/tests/test_serial_processor.py
+++ b/tests/test_serial_processor.py
@@ -1,0 +1,41 @@
+from serial_processor import process_serials
+
+
+def test_process_serials_calls_callback(monkeypatch):
+    inputs = iter(['SN12', 'SN34'])
+    collected = []
+
+    def fake_input(prompt: str) -> str:
+        return next(inputs)
+
+    def callback(serial: str) -> None:
+        collected.append(serial)
+
+    process_serials(callback, input_func=fake_input, prompts=['p1', 'p2'])
+    assert collected == ['SN12', 'SN34']
+
+
+def test_process_serials_retries(monkeypatch):
+    inputs = iter(['SN12'])
+    logs = []
+    calls = 0
+
+    def fake_input(prompt: str) -> str:
+        return next(inputs)
+
+    def callback(serial: str) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError('fail')
+
+    process_serials(
+        callback,
+        input_func=fake_input,
+        prompts=['p1'],
+        retries=1,
+        log_func=logs.append,
+    )
+
+    assert calls == 2
+    assert logs and 'fail' in logs[0]


### PR DESCRIPTION
## Summary
- add `process_serials` helper to decouple serial input from downstream handling
- cover new helper with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858283f89888320a9531069a9cf50c3