### PR TITLE
Add runtime input source manager

### DIFF
--- a/input_manager.py
+++ b/input_manager.py
@@ -1,0 +1,97 @@
+"""Manage runtime selection of serial input sources."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, TextIO, Tuple
+
+from barcode_scanner import BarcodeScanner
+from serial_input import get_serial
+
+
+class InputManager:
+    """Allow switching between manual input and barcode scanners.
+
+    Parameters
+    ----------
+    com_port : str, optional
+        Serial port used when ``scanner-COM`` is selected.
+    baudrate : int, optional
+        Baud rate for the COM scanner. Defaults to ``9600``.
+    input_stream : TextIO, optional
+        Stream object used for ``scanner-USB`` mode. Defaults to ``sys.stdin``.
+    input_func : Callable[[str], str], optional
+        Function used for manual input. Defaults to :func:`input`.
+    serial_module : object, optional
+        Module providing a ``Serial`` class, injected for testing.
+
+    Example
+    -------
+    >>> mgr = InputManager(com_port="COM3")
+    >>> mgr.set_source("scanner-USB")
+    ('scanner-USB', 'available')
+    >>> code = mgr.read_serial()
+    """
+
+    def __init__(
+        self,
+        *,
+        com_port: Optional[str] = None,
+        baudrate: int = 9600,
+        input_stream: Optional[TextIO] = None,
+        input_func: Callable[[str], str] = input,
+        serial_module: object | None = None,
+    ) -> None:
+        self.com_port = com_port
+        self.baudrate = baudrate
+        self.input_stream = input_stream
+        self.input_func = input_func
+        self.serial_module = serial_module
+        self._scanner: BarcodeScanner | None = None
+        self._source = "manual"
+        self.status = "available"
+
+    # Public API -----------------------------------------------------
+    def set_source(self, source: str) -> Tuple[str, str]:
+        """Switch to ``source`` and return ``(current_source, status)``."""
+        self.close()
+        self.status = "available"
+        if source == "manual":
+            self._source = "manual"
+            return self._source, self.status
+        if source == "scanner-USB":
+            self._scanner = BarcodeScanner(mode="usb", input_stream=self.input_stream)
+            self._source = source
+            return self._source, self.status
+        if source == "scanner-COM":
+            try:
+                self._scanner = BarcodeScanner(
+                    mode="com",
+                    port=self.com_port,
+                    baudrate=self.baudrate,
+                    serial_module=self.serial_module,
+                )
+                # Attempt to open the port to verify availability
+                self._scanner._open_serial()
+            except Exception:
+                self.status = "error"
+            self._source = source
+            return self._source, self.status
+        raise ValueError(f"Unknown source: {source}")
+
+    def read_serial(self, prompt: str = "Enter serial: ") -> str:
+        """Read a serial using the currently selected source."""
+        if self._source == "manual":
+            return get_serial(prompt, input_func=self.input_func)
+        if self._scanner is None:
+            raise RuntimeError("Scanner not initialised")
+        return self._scanner.scan()
+
+    def close(self) -> None:
+        """Close any active scanner."""
+        if self._scanner is not None:
+            self._scanner.close()
+            self._scanner = None
+
+    @property
+    def current_source(self) -> str:
+        return self._source

--- a/tests/test_input_manager.py
+++ b/tests/test_input_manager.py
@@ -1,0 +1,48 @@
+import io
+import types
+
+from input_manager import InputManager
+
+
+class DummySerial:
+    def __init__(self, *args, **kwargs):
+        self.buf = io.BytesIO(b'ABCD\r')
+        self.closed = False
+
+    def read(self, size=1):
+        return self.buf.read(size)
+
+    def close(self):
+        self.closed = True
+
+
+serial_mod = types.SimpleNamespace(Serial=DummySerial)
+
+
+def test_manual_source(monkeypatch):
+    inputs = iter(['SN123'])
+
+    def fake_input(prompt: str) -> str:
+        return next(inputs)
+
+    mgr = InputManager(input_func=fake_input)
+    src, status = mgr.set_source('manual')
+    assert (src, status) == ('manual', 'available')
+    assert mgr.read_serial() == 'SN123'
+
+
+def test_switch_to_usb():
+    stream = io.StringIO('CODE\n')
+    mgr = InputManager(input_stream=stream)
+    src, status = mgr.set_source('scanner-USB')
+    assert (src, status) == ('scanner-USB', 'available')
+    assert mgr.read_serial() == 'CODE'
+
+
+def test_switch_to_com_and_back():
+    mgr = InputManager(com_port='COM1', serial_module=serial_mod)
+    src, status = mgr.set_source('scanner-COM')
+    assert (src, status) == ('scanner-COM', 'available')
+    assert mgr.read_serial() == 'ABCD'
+    mgr.set_source('manual')
+    assert mgr.current_source == 'manual'


### PR DESCRIPTION
## Summary
- enable switching between manual input and barcode scanners at runtime
- implement new InputManager class
- add tests for the new InputManager

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582981f2948320ae6de539b179abe3