### PR TITLE
Add serial mapping manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ paths = load_paths()              # Access configured directories
 images_dir = paths["images"]
 ```
 
+## Editing Serial Mapping
+
+```python
+from serial_mapping import SerialMappingManager
+
+manager = SerialMappingManager(config_path="config/config.json")
+manager.add_mapping("ZZ99", "ModelZ")
+```
+
 ## Running Tests
 
 Run the unit tests with:

--- a/tests/test_serial_mapping.py
+++ b/tests/test_serial_mapping.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from serial_mapping import load_serial_mapping, SerialModelMap
+from serial_mapping import (
+    load_serial_mapping,
+    SerialModelMap,
+    SerialMappingManager,
+)
 
 
 def test_load_serial_mapping(tmp_path: Path):
@@ -39,3 +43,33 @@ def test_serial_model_map_get(tmp_path: Path):
     mapper = SerialModelMap(config_path=cfg)
     assert mapper.get_model("CD34XXXX") == "ModelB"
     assert mapper.get_model("XXYY", default="Unknown") == "Unknown"
+
+
+def test_serial_mapping_manager_edit(tmp_path: Path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"serialMapping": {"AA11": "Old"}}))
+
+    mgr = SerialMappingManager(config_path=cfg)
+    assert mgr.add_mapping("BB22", "New") == "added"
+    data = json.loads(cfg.read_text())
+    assert data["serialMapping"]["BB22"] == "New"
+
+    assert mgr.update_mapping("BB22", "Newer") == "updated"
+    data = json.loads(cfg.read_text())
+    assert data["serialMapping"]["BB22"] == "Newer"
+
+    assert mgr.remove_mapping("BB22") == "removed"
+    data = json.loads(cfg.read_text())
+    assert "BB22" not in data["serialMapping"]
+
+
+def test_serial_mapping_manager_errors(tmp_path: Path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"serialMapping": {"AA11": "Old"}}))
+
+    mgr = SerialMappingManager(config_path=cfg)
+    assert mgr.add_mapping("AA11", "Dup") == "error: prefix exists"
+    assert mgr.update_mapping("ZZ99", "None") == "error: prefix not found"
+    assert mgr.remove_mapping("ZZ99") == "error: prefix not found"
+    data = json.loads(cfg.read_text())
+    assert data["serialMapping"] == {"AA11": "Old"}


### PR DESCRIPTION
## Summary
- add SerialMappingManager for editing mapping configs
- document editing in README
- test add, update and remove operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582d636eb083208a498d74fc2ef75f