### PR TITLE
Add model API for managing serial mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ manager = SerialMappingManager(config_path="config/config.json")
 manager.add_mapping("ZZ99", "ModelZ")
 ```
 
+## Model Selection API
+
+Convenience functions in ``model_api`` wrap the mapping manager and
+model selector for use in other modules.
+
+```python
+from model_api import (
+    select_model,
+    add_mapping,
+    remove_mapping,
+    reload_mapping,
+)
+
+reload_mapping("config/config.json")
+model = select_model("AB12XXXX")
+add_mapping("ZZ99", "ModelZ")
+remove_mapping("AB12")
+```
+
 ## Running Tests
 
 Run the unit tests with:

--- a/model_api.py
+++ b/model_api.py
@@ -1,0 +1,57 @@
+"""API wrapper for selecting models and editing serial mappings."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from model_selector import ModelSelector
+from serial_mapping import SerialMappingManager
+
+
+_config_path = Path("config/config.json")
+_mapping_manager: SerialMappingManager | None = None
+_selector: ModelSelector | None = None
+
+
+def _load() -> None:
+    """(Re)load mapping and selector from ``_config_path``."""
+    global _mapping_manager, _selector
+    _mapping_manager = SerialMappingManager(config_path=_config_path)
+    _selector = ModelSelector(mapping=_mapping_manager.as_dict())
+
+
+def reload_mapping(config_path: str | Path | None = None) -> None:
+    """Reload mapping from ``config_path`` or the existing path."""
+    global _config_path
+    if config_path is not None:
+        _config_path = Path(config_path)
+    _load()
+
+
+def select_model(serial: str, *, unknown: Optional[str] = None) -> Optional[str]:
+    """Return the model name for ``serial`` using the loaded mapping."""
+    if _selector is None:
+        _load()
+    return _selector.select(serial, unknown=unknown)
+
+
+def add_mapping(prefix: str, model: str) -> str:
+    """Add ``prefix`` mapping and persist the config."""
+    if _mapping_manager is None:
+        _load()
+    result = _mapping_manager.add_mapping(prefix, model)
+    global _selector
+    _selector = ModelSelector(mapping=_mapping_manager.as_dict())
+    return result
+
+
+def remove_mapping(prefix: str) -> str:
+    """Remove ``prefix`` mapping from the config."""
+    if _mapping_manager is None:
+        _load()
+    result = _mapping_manager.remove_mapping(prefix)
+    global _selector
+    _selector = ModelSelector(mapping=_mapping_manager.as_dict())
+    return result
+

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+import model_api
+
+
+def test_select_and_modify(tmp_path: Path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"serialMapping": {"AA11": "Model1"}}))
+    model_api.reload_mapping(cfg)
+
+    assert model_api.select_model("AA11xxxx") == "Model1"
+    assert model_api.select_model("ZZ99", unknown="Unknown") == "Unknown"
+
+    assert model_api.add_mapping("BB22", "Model2") == "added"
+    assert model_api.select_model("BB22abcd") == "Model2"
+
+    assert model_api.remove_mapping("AA11") == "removed"
+    assert model_api.select_model("AA11abcd") is None
+
+
+def test_reload_mapping(tmp_path: Path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"serialMapping": {"CC33": "Model3"}}))
+    model_api.reload_mapping(cfg)
+    assert model_api.select_model("CC33aaaa") == "Model3"
+
+    cfg.write_text(json.dumps({"serialMapping": {"DD44": "Model4"}}))
+    model_api.reload_mapping()  # reload same path
+    assert model_api.select_model("DD44bbbb") == "Model4"


### PR DESCRIPTION
## Summary
- add `model_api` module providing high level functions for model selection
- document new API usage in README
- test the new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68583004e53c8320baeb516b6639a9ee