### PR TITLE
Add EventLogger with file persistence

### DIFF
--- a/event_logger.py
+++ b/event_logger.py
@@ -1,0 +1,62 @@
+"""Simple event logging utility."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import json
+
+
+@dataclass
+class LogEntry:
+    """Data structure representing a single log event."""
+
+    timestamp: str
+    event_type: str
+    message: str
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class EventLogger:
+    """Store log events in memory and append them to a file.
+
+    Parameters
+    ----------
+    file_path : str or Path
+        Path to the file where events are appended.
+    """
+
+    def __init__(self, file_path: str | Path) -> None:
+        self.file_path = Path(file_path)
+        self.logs: List[LogEntry] = []
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        self.file_path.touch(exist_ok=True)
+
+    def log_event(
+        self,
+        event_type: str,
+        message: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Log an event with optional metadata.
+
+        Parameters
+        ----------
+        event_type : str
+            Type/category of the event.
+        message : str
+            Human readable description for the event.
+        metadata : dict, optional
+            Extra metadata associated with the event.
+        """
+        entry = LogEntry(
+            timestamp=datetime.now().isoformat(timespec="seconds"),
+            event_type=event_type,
+            message=message,
+            metadata=metadata,
+        )
+        self.logs.append(entry)
+        with self.file_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(asdict(entry)) + "\n")

--- a/tests/test_event_logger.py
+++ b/tests/test_event_logger.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import json
+from event_logger import EventLogger
+
+
+def test_log_event_stores_and_appends(tmp_path: Path):
+    log_file = tmp_path / "log.txt"
+    logger = EventLogger(log_file)
+
+    logger.log_event("info", "started", {"user": "abc"})
+
+    assert len(logger.logs) == 1
+    entry = logger.logs[0]
+    assert entry.event_type == "info"
+    assert entry.message == "started"
+    assert entry.metadata == {"user": "abc"}
+    assert entry.timestamp
+
+    data = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert data == [
+        {
+            "timestamp": entry.timestamp,
+            "event_type": "info",
+            "message": "started",
+            "metadata": {"user": "abc"},
+        }
+    ]
+
+
+def test_log_event_appends_multiple(tmp_path: Path):
+    log_file = tmp_path / "log.txt"
+    logger = EventLogger(log_file)
+
+    logger.log_event("info", "first")
+    logger.log_event("warn", "second")
+
+    assert len(logger.logs) == 2
+    lines = log_file.read_text().splitlines()
+    assert len(lines) == 2


### PR DESCRIPTION
## Summary
- add `EventLogger` class for logging events with optional metadata
- record events in memory and append to a file
- test event logging functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858316e58bc832099d95b5d6a4742d2