### PR TITLE
Add log save/load helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ add_mapping("ZZ99", "ModelZ")
 remove_mapping("AB12")
 ```
 
+## Event Logger
+
+Keep a list of events in memory and export or reload them.
+
+```python
+from event_logger import EventLogger
+
+logger = EventLogger("logs/events.txt")
+logger.log_event("info", "started", {"user": "abc"})
+
+logger.save_log_json("events.json")
+logger.save_log_csv("events.csv")
+
+logger.load_log_json("events.json")
+logger.load_log_csv("events.csv")
+```
+
 ## Running Tests
 
 Run the unit tests with:

--- a/tests/test_event_logger.py
+++ b/tests/test_event_logger.py
@@ -37,3 +37,63 @@ def test_log_event_appends_multiple(tmp_path: Path):
     assert len(logger.logs) == 2
     lines = log_file.read_text().splitlines()
     assert len(lines) == 2
+
+
+def test_save_and_load_json(tmp_path: Path):
+    log_file = tmp_path / "log.txt"
+    logger = EventLogger(log_file)
+    logger.log_event("info", "start", {"a": 1})
+
+    out = tmp_path / "events.json"
+    logger.save_log_json(out)
+
+    new_logger = EventLogger(tmp_path / "new.txt")
+    new_logger.load_log_json(out)
+
+    assert len(new_logger.logs) == 1
+    entry = new_logger.logs[0]
+    assert entry.event_type == "info"
+    assert entry.metadata == {"a": 1}
+
+
+def test_save_and_load_csv(tmp_path: Path):
+    log_file = tmp_path / "log.txt"
+    logger = EventLogger(log_file)
+    logger.log_event("warn", "oops", {"b": 2})
+
+    csv_path = tmp_path / "events.csv"
+    logger.save_log_csv(csv_path)
+
+    other = EventLogger(tmp_path / "other.txt")
+    other.load_log_csv(csv_path)
+
+    assert len(other.logs) == 1
+    entry = other.logs[0]
+    assert entry.message == "oops"
+    assert entry.metadata == {"b": 2}
+
+
+def test_load_json_invalid_or_missing(tmp_path: Path):
+    logger = EventLogger(tmp_path / "log.txt")
+
+    missing = tmp_path / "missing.json"
+    logger.load_log_json(missing)
+    assert logger.logs == []
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json")
+    logger.load_log_json(bad)
+    assert logger.logs == []
+
+
+def test_load_csv_invalid_or_missing(tmp_path: Path):
+    logger = EventLogger(tmp_path / "log.txt")
+
+    missing = tmp_path / "missing.csv"
+    logger.load_log_csv(missing)
+    assert logger.logs == []
+
+    bad = tmp_path / "bad.csv"
+    bad.write_text("bad,data")
+    logger.load_log_csv(bad)
+    assert logger.logs == []


### PR DESCRIPTION
## Summary
- extend `EventLogger` with CSV/JSON save/load methods
- document event logger usage
- test saving and loading of logs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68583473c79883209aff885fe1491af3