### PR TITLE
Add log table export

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ logger.save_log_csv("events.csv")
 
 logger.load_log_json("events.json")
 logger.load_log_csv("events.csv")
+
+# Convert log list to a DataFrame or HTML table
+from event_logger import logs_to_dataframe
+
+df = logs_to_dataframe(logger.logs)
+html = logs_to_dataframe(logger.logs, as_html=True)
 ```
 
 ## Running Tests

--- a/event_logger.py
+++ b/event_logger.py
@@ -138,3 +138,32 @@ class EventLogger:
             self.logs = logs
         except (csv.Error, json.JSONDecodeError, TypeError, KeyError):
             self.logs = []
+
+
+def logs_to_dataframe(logs: List[LogEntry], *, as_html: bool = False):
+    """Return a pandas DataFrame or HTML table for ``logs``.
+
+    Parameters
+    ----------
+    logs : list[LogEntry]
+        List of log entries to convert.
+    as_html : bool, optional
+        When ``True`` return an HTML table string instead of a
+        :class:`pandas.DataFrame`.
+
+    Returns
+    -------
+    pandas.DataFrame or str
+        DataFrame representing ``logs`` or HTML table string when
+        ``as_html`` is ``True``.
+    """
+
+    try:
+        import pandas as pd  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise ImportError("pandas is required for logs_to_dataframe") from exc
+
+    df = pd.DataFrame([asdict(e) for e in logs])
+    if as_html:
+        return df.to_html(index=False)
+    return df

--- a/tests/test_log_table.py
+++ b/tests/test_log_table.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+import pytest
+
+from event_logger import EventLogger, logs_to_dataframe
+
+
+def test_logs_to_dataframe_and_html(tmp_path: Path):
+    pandas = pytest.importorskip("pandas")
+
+    log_file = tmp_path / "log.txt"
+    logger = EventLogger(log_file)
+    logger.log_event("info", "start", {"a": 1})
+    logger.log_event("warn", "stop")
+
+    df = logs_to_dataframe(logger.logs)
+    assert list(df.columns) == ["timestamp", "event_type", "message", "metadata"]
+    assert df.iloc[0]["message"] == "start"
+
+    html = logs_to_dataframe(logger.logs, as_html=True)
+    assert "<table" in html and "</table>" in html


### PR DESCRIPTION
## Summary
- export logs as a dataframe or HTML string
- document table conversion in README
- test log table conversion (skipped if pandas missing)

## Testing
- `pytest tests/test_log_table.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685835dc4b1083208eeb3f889d3eaed1