### PR TITLE
Add cross-platform screenshot utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ df = logs_to_dataframe(logger.logs)
 html = logs_to_dataframe(logger.logs, as_html=True)
 ```
 
+## Screenshot Utility
+
+Capture desktop images using the :class:`ScreenCapture` class.
+
+```python
+from screenshot import ScreenCapture
+
+cap = ScreenCapture()
+
+# Full screen capture as a PIL image
+image = cap.capture()
+
+# Capture a specific window by its title
+window_image = cap.capture(window="Untitled - Notepad")
+
+# Capture a custom region and return a NumPy array
+array = cap.capture(region=(0, 0, 300, 200), as_numpy=True)
+
+# Save the capture to a temporary file
+path = cap.capture(to_file=True)
+```
+
 ## Running Tests
 
 Run the unit tests with:

--- a/screenshot.py
+++ b/screenshot.py
@@ -1,0 +1,98 @@
+"""Cross-platform screenshot utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple, Optional, Union
+import tempfile
+
+try:
+    from PIL import Image  # type: ignore
+except Exception as exc:  # pragma: no cover - pillow optional
+    raise ImportError("Pillow is required for screenshot functionality") from exc
+
+try:
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - numpy optional
+    np = None  # type: ignore
+
+try:
+    import mss  # type: ignore
+except Exception as exc:  # pragma: no cover - mss optional
+    raise ImportError("mss is required for screenshot functionality") from exc
+
+try:
+    import pyautogui  # type: ignore
+except Exception:
+    pyautogui = None  # type: ignore
+
+
+class ScreenCapture:
+    """Capture screenshots of the desktop or application windows."""
+
+    def __init__(self) -> None:
+        self._sct = mss.mss()
+
+    # Internal helpers -------------------------------------------------
+    def _grab(self, region: dict) -> Image.Image:
+        """Return a :class:`PIL.Image.Image` for ``region``."""
+        img = self._sct.grab(region)
+        return Image.frombytes("RGB", img.size, img.bgra, "raw", "BGRX")
+
+    def _get_window_box(self, title: str) -> dict:
+        """Return bounding box for the first window matching ``title``."""
+        if pyautogui is None:
+            raise RuntimeError("pyautogui is required for window capture")
+        wins = pyautogui.getWindowsWithTitle(title)
+        if not wins:
+            raise ValueError(f"Window not found: {title}")
+        win = wins[0]
+        return {"left": win.left, "top": win.top, "width": win.width, "height": win.height}
+
+    # Public API -------------------------------------------------------
+    def capture(
+        self,
+        *,
+        window: Optional[str] = None,
+        region: Optional[Tuple[int, int, int, int]] = None,
+        as_numpy: bool = False,
+        to_file: bool = False,
+    ) -> Union[Image.Image, "np.ndarray", Path]:
+        """Capture the screen, a window, or a region.
+
+        Parameters
+        ----------
+        window : str, optional
+            Title of the window to capture.
+        region : tuple[int, int, int, int], optional
+            ``(x, y, width, height)`` region to capture.
+        as_numpy : bool, optional
+            When ``True`` return a NumPy array instead of :class:`~PIL.Image.Image`.
+        to_file : bool, optional
+            When ``True`` save the capture to a temporary PNG file and return the
+            :class:`pathlib.Path`.
+        """
+        if window and region:
+            raise ValueError("Specify only one of window or region")
+
+        if window:
+            box = self._get_window_box(window)
+        elif region:
+            x, y, w, h = region
+            box = {"left": x, "top": y, "width": w, "height": h}
+        else:
+            box = self._sct.monitors[1]
+
+        image = self._grab(box)
+
+        if to_file:
+            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+            Path(tmp.name).write_bytes(image.tobytes())
+            image.save(tmp.name)
+            return Path(tmp.name)
+
+        if as_numpy:
+            if np is None:
+                raise RuntimeError("NumPy is required for as_numpy=True")
+            return np.array(image)
+        return image

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from PIL import Image
+import numpy as np
+
+from screenshot import ScreenCapture
+
+
+def test_capture_returns_image(monkeypatch):
+    sc = ScreenCapture()
+    dummy = Image.new("RGB", (10, 10), "red")
+    monkeypatch.setattr(sc, "_grab", lambda box: dummy)
+    img = sc.capture()
+    assert isinstance(img, Image.Image)
+    assert img.size == (10, 10)
+
+
+def test_capture_numpy(monkeypatch):
+    sc = ScreenCapture()
+    dummy = Image.new("RGB", (5, 5), "blue")
+    monkeypatch.setattr(sc, "_grab", lambda box: dummy)
+    arr = sc.capture(region=(0, 0, 5, 5), as_numpy=True)
+    assert isinstance(arr, np.ndarray)
+    assert arr.shape == (5, 5, 3)
+
+
+def test_capture_file(monkeypatch, tmp_path):
+    sc = ScreenCapture()
+    dummy = Image.new("RGB", (4, 4), "green")
+    monkeypatch.setattr(sc, "_grab", lambda box: dummy)
+    path = sc.capture(to_file=True)
+    assert isinstance(path, Path)
+    assert path.is_file()
+    img = Image.open(path)
+    assert img.size == (4, 4)


### PR DESCRIPTION
## Summary
- implement new `ScreenCapture` class for taking screenshots
- add usage examples to README
- test basic screenshot behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy', ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68583718044c8320ab38718dcf7e437c