### PR TITLE
Add screenshot naming helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ array = cap.capture(region=(0, 0, 300, 200), as_numpy=True)
 path = cap.capture(to_file=True)
 ```
 
+Use :func:`make_screenshot_name` to generate filenames for saved captures.
+
+```python
+from screenshot_namer import make_screenshot_name
+
+name = make_screenshot_name("SN123", "pass")
+```
+
 ## Running Tests
 
 Run the unit tests with:

--- a/screenshot_namer.py
+++ b/screenshot_namer.py
@@ -1,0 +1,41 @@
+"""Filename helper for screenshots."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+
+def make_screenshot_name(
+    serial: str,
+    result: str,
+    timestamp: datetime | None = None,
+    dest_dir: str | Path | None = None,
+) -> str:
+    """Return a screenshot filename.
+
+    Parameters
+    ----------
+    serial : str
+        Device serial number.
+    result : str
+        Result status for the capture.
+    timestamp : datetime, optional
+        Timestamp used for the filename. Defaults to :func:`datetime.now`.
+    dest_dir : str or Path, optional
+        Directory to prepend to the filename. When provided, "_1", "_2", ...
+        is appended until a unique filename is found.
+    """
+    ts = (timestamp or datetime.now()).strftime("%Y%m%d_%H%M%S")
+    base = f"{serial}_{result}_{ts}.jpg"
+    if dest_dir is None:
+        return base
+
+    directory = Path(dest_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    name = directory / base
+    counter = 1
+    while name.exists():
+        name = directory / f"{serial}_{result}_{ts}_{counter}.jpg"
+        counter += 1
+    return str(name)

--- a/tests/test_screenshot_namer.py
+++ b/tests/test_screenshot_namer.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from pathlib import Path
+
+from screenshot_namer import make_screenshot_name
+
+
+def test_make_name_fixed_timestamp():
+    ts = datetime(2024, 1, 2, 3, 4, 5)
+    name = make_screenshot_name("SN12", "ok", timestamp=ts)
+    assert name == "SN12_ok_20240102_030405.jpg"
+
+
+def test_make_name_increments(tmp_path: Path):
+    ts = datetime(2024, 1, 2, 3, 4, 5)
+    base = tmp_path
+    first = base / "SN12_ok_20240102_030405.jpg"
+    first.touch()
+    name1 = make_screenshot_name("SN12", "ok", timestamp=ts, dest_dir=base)
+    assert Path(name1).name == "SN12_ok_20240102_030405_1.jpg"
+    Path(name1).touch()
+    name2 = make_screenshot_name("SN12", "ok", timestamp=ts, dest_dir=base)
+    assert Path(name2).name == "SN12_ok_20240102_030405_2.jpg"


### PR DESCRIPTION
## Summary
- add `screenshot_namer.py` for generating screenshot filenames
- test `make_screenshot_name` behaviour
- document usage in README

## Testing
- `pytest -q` *(fails: No module named 'numpy', 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_685839b4fef88320927e2c7cd0d4f8d3