### PR TITLE
Add screenshot saving utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ from screenshot_namer import make_screenshot_name
 name = make_screenshot_name("SN123", "pass")
 ```
 
+Save one or more images with :func:`save_screenshot`::
+
+```python
+from screenshot import ScreenCapture, save_screenshot
+
+cap = ScreenCapture()
+for i in range(3):
+    img = cap.capture()
+    save_screenshot(img, "captures", f"shot_{i+1}.png")
+```
+
 ## Running Tests
 
 Run the unit tests with:

--- a/tests/test_save_screenshot.py
+++ b/tests/test_save_screenshot.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from PIL import Image
+import pytest
+
+from screenshot import save_screenshot
+
+
+def test_save_creates_directory(tmp_path: Path):
+    img = Image.new("RGB", (2, 2), "white")
+    dest = tmp_path / "shots"
+    out = save_screenshot(img, dest, "img.png")
+    assert out == dest / "img.png"
+    assert out.is_file()
+
+
+def test_save_logs_error(monkeypatch, tmp_path: Path):
+    img = Image.new("RGB", (1, 1))
+    messages = []
+    
+    def fail_save(path):
+        raise OSError("fail")
+
+    monkeypatch.setattr(img, "save", fail_save)
+    with pytest.raises(OSError):
+        save_screenshot(img, tmp_path, "bad.png", log_func=messages.append)
+    assert messages and "fail" in messages[0]


### PR DESCRIPTION
## Summary
- implement `save_screenshot` helper
- document saving multiple images
- add unit tests for `save_screenshot`

## Testing
- `pytest -q` *(fails: No module named 'numpy', No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68583acdde6c8320af231194a1ec8180