### PR TITLE
Use context manager for temp screenshot file

### DIFF
--- a/screenshot.py
+++ b/screenshot.py
@@ -86,9 +86,8 @@ class ScreenCapture:
         image = self._grab(box)
 
         if to_file:
-            tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
-            Path(tmp.name).write_bytes(image.tobytes())
-            image.save(tmp.name)
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                image.save(tmp.name)
             return Path(tmp.name)
 
         if as_numpy:


### PR DESCRIPTION
## Summary
- use a context manager for the temporary screenshot file
- save the image in that context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68595d537ee08320ba9c1bad516731d1