### PR TITLE
Add prefix validation and register model dialog

### DIFF
--- a/register_model_dialog.py
+++ b/register_model_dialog.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QMessageBox,
+)
+
+from serial_input import validate_prefix
+
+
+class RegisterModelDialog(QDialog):
+    """Dialog to register a serial prefix mapping."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Register Model")
+        layout = QFormLayout(self)
+
+        self.prefix_input = QLineEdit()
+        self.model_input = QLineEdit()
+
+        layout.addRow("Serial Prefix (4 chars):", self.prefix_input)
+        layout.addRow("Model Name:", self.model_input)
+
+        self.buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.buttons.accepted.connect(self._on_accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addWidget(self.buttons)
+
+    def _on_accept(self) -> None:
+        prefix = self.prefix_input.text().strip().upper()
+        model = self.model_input.text().strip()
+        if not validate_prefix(prefix):
+            QMessageBox.warning(self, "Invalid Prefix", "Prefix must be 4 alphanumeric characters.")
+            return
+        if not model:
+            QMessageBox.warning(self, "Invalid Model", "Model name is required.")
+            return
+        self.prefix_input.setText(prefix)
+        self.accept()
+
+    def get_data(self) -> tuple[str, str]:
+        """Return the entered prefix and model."""
+        return self.prefix_input.text(), self.model_input.text()

--- a/serial_input.py
+++ b/serial_input.py
@@ -8,6 +8,11 @@ def validate_serial(serial: str) -> bool:
     return serial.isalnum() and 4 <= len(serial) <= 20
 
 
+def validate_prefix(prefix: str) -> bool:
+    """Return ``True`` if ``prefix`` is exactly 4 alphanumeric characters."""
+    return len(prefix) == 4 and prefix.isalnum()
+
+
 def get_serial(
     prompt: str = "Enter serial: ",
     *,

--- a/tests/test_serial_input.py
+++ b/tests/test_serial_input.py
@@ -1,6 +1,6 @@
 import builtins
 
-from serial_input import validate_serial, get_serial
+from serial_input import validate_serial, validate_prefix, get_serial
 
 
 def test_validate_serial():
@@ -10,6 +10,13 @@ def test_validate_serial():
     assert not validate_serial('abc')
     assert not validate_serial('a' * 21)
     assert not validate_serial('123$')
+
+
+def test_validate_prefix():
+    assert validate_prefix('AB12')
+    assert not validate_prefix('ABC')
+    assert not validate_prefix('ABCDE')
+    assert not validate_prefix('AB!2')
 
 
 def test_get_serial(monkeypatch):

--- a/ui_main.py
+++ b/ui_main.py
@@ -1,10 +1,27 @@
 from PyQt5.QtWidgets import (
-    QApplication, QWidget, QPushButton, QLabel, QLineEdit, QComboBox,
-    QVBoxLayout, QHBoxLayout, QGridLayout, QTextEdit, QTableWidget,
-    QTableWidgetItem, QGroupBox, QStatusBar, QFileDialog, QMessageBox
+    QApplication,
+    QWidget,
+    QPushButton,
+    QLabel,
+    QLineEdit,
+    QComboBox,
+    QVBoxLayout,
+    QHBoxLayout,
+    QGridLayout,
+    QTextEdit,
+    QTableWidget,
+    QTableWidgetItem,
+    QGroupBox,
+    QStatusBar,
+    QFileDialog,
+    QMessageBox,
+    QDialog,
 )
 from PyQt5.QtCore import Qt, QTimer, QDateTime
 from PyQt5.QtGui import QPixmap
+
+import model_api
+from register_model_dialog import RegisterModelDialog
 
 import sys
 import datetime
@@ -208,7 +225,14 @@ class VisionInspectionUI(QWidget):
         QMessageBox.information(self, "Screenshot", f"Screenshot saved:\n{fname}")
 
     def handle_register_model(self):
-        QMessageBox.information(self, "Register Model", "ยังไม่ implement (mock)")
+        dialog = RegisterModelDialog(self)
+        if dialog.exec_() == QDialog.Accepted:
+            prefix, model = dialog.get_data()
+            result = model_api.add_mapping(prefix, model)
+            if result == "added":
+                QMessageBox.information(self, "Register Model", f"Added mapping {prefix} -> {model}")
+            else:
+                QMessageBox.warning(self, "Register Model", result)
 
     def handle_config(self):
         QMessageBox.information(self, "Config", "ยังไม่ implement (mock)")


### PR DESCRIPTION
## Summary
- validate serial prefixes
- expose RegisterModelDialog for PyQt GUI model registration
- wire up new dialog in UI
- cover prefix validation in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6859872c7cc08320a9a53ce2b3fd19c4